### PR TITLE
hotfix for moving array to a guild without missing its value

### DIFF
--- a/guild.c
+++ b/guild.c
@@ -350,7 +350,7 @@ guild_channel_move(VALUE obj)
 			}
 		    }
 		}
-		memcpy((VALUE *)dst+2, (VALUE *)obj + 2, sizeof(VALUE) * 3);
+		rb_array_replace(dst, obj);
 		if (FL_TEST(obj, RARRAY_EMBED_FLAG)) FL_SET(dst, RARRAY_EMBED_FLAG);
 
 		/* reset src obj */


### PR DESCRIPTION
Guild に配列を move すると、送り手側の配列は invalidate されるはずです。しかし、今の実装で動作確認をすると、受け手側でも配列は空になってしまうようです。

再現コード（Ubuntu 18.04 で guild ブランチを checkout し、ビルドしたあと、irb 上で実験しています）
```
> g = Guild.new{v = Guild.receive; p v}
> a = [1,2,3]
> g.move a
=> nil
[] # これは g が表示している。a を送ったので [1,2,3] と表示してほしいが、[] になっている
> a
[] # aの値が[]になるのはおそらく意図通り
```

guild.c を眺めると、例えば Hash の move などは未対応のようですが、Array の move は実装されているようなので、これは意図していない挙動ではないかと思っています。

あまり根拠はありませんが、この PR で書き換えている `memcpy` が怪しいと思っています。array のメモリレイアウトを覚えていないため、ひとまず `rb_array_replace` で置き換えてみたところ、値が届くようになりました。このPRの実装は、暫定的なものです。