### PR TITLE
fix compile error on mac

### DIFF
--- a/ractor.c
+++ b/ractor.c
@@ -1079,7 +1079,7 @@ ractor_close_outgoing(rb_execution_context_t *ec, rb_ractor_t *r)
 
 // creation/termination
 
-static VALUE
+static uint32_t
 ractor_next_id(void)
 {
     // TODO: lock


### PR DESCRIPTION
I caught compilation error when I tried to build ractor branch on my macOS.
I just found the `ractor_next_id`'s return type is incorrect and fix it.

The error message is the following:

```
../ruby/ractor.c:1105:13: error: implicit conversion loses integer precision: 'VALUE' (aka 'unsigned long') to 'uint32_t' (aka 'unsigned int')
      [-Werror,-Wshorten-64-to-32]
    r->id = ractor_next_id();
          ~ ^~~~~~~~~~~~~~~~
```

